### PR TITLE
unsafe impl Send for ProfilerMarkerDesc

### DIFF
--- a/unity-native-plugin/src/profiler.rs
+++ b/unity-native-plugin/src/profiler.rs
@@ -134,9 +134,12 @@ impl ProfilerMarkerEventType {
 
 pub type ProfilerMarkerId = UnityProfilerMarkerId;
 
+#[derive(Clone)]
 pub struct ProfilerMarkerDesc {
     pub(crate) native: *const UnityProfilerMarkerDesc,
 }
+
+unsafe impl Send for ProfilerMarkerDesc {}
 
 impl std::fmt::Debug for ProfilerMarkerDesc {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/unity-native-plugin/src/profiler_callbacks.rs
+++ b/unity-native-plugin/src/profiler_callbacks.rs
@@ -50,7 +50,7 @@ impl ProfilerThreadDesc {
 }
 
 pub struct ProfilerMarkerEvent<'a> {
-    pub desc: &'a ProfilerMarkerDesc,
+    pub desc: ProfilerMarkerDesc,
     pub event_type: ProfilerMarkerEventType,
     event_data: &'a [UnityProfilerMarkerData],
 }
@@ -107,7 +107,7 @@ extern "system" fn marker_event_bridge(
     let event_data = unsafe { std::slice::from_raw_parts(_event_data, _event_data_count as usize) };
 
     let desc = ProfilerMarkerEvent {
-        desc: &desc,
+        desc,
         event_type,
         event_data,
     };


### PR DESCRIPTION
It seems UnityProfilerMarkerDesc is thread-safe, so add `unsafe impl Send` marker on it.