### PR TITLE
Add Metal sample to fill_texture plugin

### DIFF
--- a/unity-native-plugin-sample/Cargo.toml
+++ b/unity-native-plugin-sample/Cargo.toml
@@ -11,12 +11,16 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-unity-native-plugin = { version = "0.9.0",  path = "../unity-native-plugin", features = ["d3d11", "d3d12", "profiler", "vulkan"] }
+unity-native-plugin = { version = "0.9.0",  path = "../unity-native-plugin", features = ["d3d11", "d3d12", "metal", "profiler", "vulkan"] }
 unity-native-plugin-sys = { version = "0.9.0", path = "../unity-native-plugin-sys" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "d3d11", "d3d12", "dxgiformat", "d3dcommon"] }
 wio = "0.2.2"
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+objc2 = "0.6.3"
+objc2-metal = "0.3.2"
 
 [dev-dependencies]
 unity-native-plugin-tester = { version = "0.9.0",  path = "../unity-native-plugin-tester", features = ["d3d11"] }

--- a/unity-native-plugin-sample/README.md
+++ b/unity-native-plugin-sample/README.md
@@ -1,6 +1,6 @@
 # unity-native-plugin-sample
 
-A Rust-based Unity native plugin sample that fills a `RenderTexture` (or `Texture`) with a solid color. Supports three Graphics APIs: Direct3D11 / Direct3D12 / Vulkan.
+A Rust-based Unity native plugin sample that fills a `RenderTexture` (or `Texture`) with a solid color. Supports four Graphics APIs: Direct3D11 / Direct3D12 / Vulkan / Metal.
 
 ## Build
 
@@ -29,15 +29,17 @@ typedef struct {
 ```
 
 > **Note**
-> `IUnityGraphicsD3D12v8::CommandRecordingState` and `IUnityGraphicsVulkan::CommandRecordingState` return a valid command list / command buffer **only while Unity's render thread is executing a Plugin Event callback**. For this reason, this plugin's API is designed to be invoked through `CommandBuffer.IssuePluginEventAndData`. No API for performing the fill directly from the main thread (via `DllImport`) is intentionally provided.
+> `IUnityGraphicsD3D12v8::CommandRecordingState`, `IUnityGraphicsVulkan::CommandRecordingState`, and `IUnityGraphicsMetal::CurrentCommandBuffer` return a valid command list / command buffer **only while Unity's render thread is executing a Plugin Event callback**. For this reason, this plugin's API is designed to be invoked through `CommandBuffer.IssuePluginEventAndData`. No API for performing the fill directly from the main thread (via `DllImport`) is intentionally provided.
 >
 > For Vulkan, the plugin internally calls `IUnityGraphicsVulkan::ConfigureEvent` during `UnityPluginLoad` with `graphicsQueueAccess = DontCare`, `renderPassPrecondition = EnsureOutside`, and `flags = EnsurePreviousFrameSubmission | ModifiesCommandBuffersState`. Without these flags Unity does not provide a valid command buffer to the event callback.
 >
 > For Direct3D12, the plugin requires `IUnityGraphicsD3D12v8` (it falls back to v7 / v6 only for `ConfigureEvent`, but the actual fill uses v8's `RequestResourceState` / `NotifyResourceState` API for resource state transitions). Older interfaces will not perform the transition and the fill will silently do nothing.
+>
+> For Metal, the plugin uses `IUnityGraphicsMetalV2` (falling back to `V1`) to obtain the current `MTLCommandBuffer`. It calls `EndCurrentCommandEncoder` to close any encoder Unity has open, then encodes a one-shot render pass with `loadAction = Clear` against the Unity-provided `id<MTLTexture>` (the value returned by `Texture.GetNativeTexturePtr()` under Metal).
 
 ## C# Usage
 
-A working sample MonoBehaviour is provided at [`csharp/FillTextureTest.cs`](./csharp/FillTextureTest.cs). Drop it on a `GameObject` with a `Renderer`, set Graphics API to D3D11 / D3D12 / Vulkan, and the attached material's main texture is filled by the plugin every frame.
+A working sample MonoBehaviour is provided at [`csharp/FillTextureTest.cs`](./csharp/FillTextureTest.cs). Drop it on a `GameObject` with a `Renderer`, set Graphics API to D3D11 / D3D12 / Vulkan / Metal, and the attached material's main texture is filled by the plugin every frame.
 
 The command buffer must be dispatched in a way that runs on Unity's render thread. The correct dispatch path depends on the active render pipeline:
 
@@ -48,7 +50,7 @@ The command buffer must be dispatched in a way that runs on Unity's render threa
 
 - `IssuePluginEventAndData` executes **deferred on the render thread**. The pointer you pass must remain valid until the callback completes, so allocate parameters in a non-GC region such as `Marshal.AllocHGlobal` or `NativeArray<T>(Allocator.Persistent)`.
 - The return value of `GetFillTextureCallback()` can be cached after the first call.
-- Under Direct3D12 and Vulkan, any other path (such as calling the plugin directly from the main thread) will not have a valid `CommandRecordingState`, and the fill will silently do nothing.
+- Under Direct3D12, Vulkan, and Metal, any other path (such as calling the plugin directly from the main thread) will not have a valid current command list / command buffer, and the fill will silently do nothing.
 - Under URP / HDRP, `Camera.AddCommandBuffer` is ignored. Use `RenderPipelineManager.beginCameraRendering` (or a `ScriptableRendererFeature` for URP) to inject the command buffer.
 
 ## References

--- a/unity-native-plugin-sample/src/lib.rs
+++ b/unity-native-plugin-sample/src/lib.rs
@@ -2,6 +2,8 @@
 mod d3d11;
 #[cfg(windows)]
 mod d3d12;
+#[cfg(target_vendor = "apple")]
+mod metal;
 mod vulkan;
 
 use std::ffi::c_void;
@@ -82,6 +84,8 @@ fn dispatch_fill_texture(texture: *mut c_void, x: f32, y: f32, z: f32, w: f32) {
         #[cfg(windows)]
         Some(GfxRenderer::D3D12) => d3d12::fill_texture(texture, x, y, z, w),
         Some(GfxRenderer::Vulkan) => vulkan::fill_texture(texture, x, y, z, w),
+        #[cfg(target_vendor = "apple")]
+        Some(GfxRenderer::Metal) => metal::fill_texture(texture, x, y, z, w),
         _ => {}
     }
 }

--- a/unity-native-plugin-sample/src/metal.rs
+++ b/unity-native-plugin-sample/src/metal.rs
@@ -1,0 +1,63 @@
+use std::ffi::c_void;
+
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2_metal::{
+    MTLClearColor, MTLCommandBuffer, MTLCommandEncoder, MTLLoadAction, MTLRenderPassDescriptor,
+    MTLStoreAction, MTLTexture,
+};
+
+use unity_native_plugin::interface::UnityInterfaces;
+use unity_native_plugin::metal::objc2::{
+    UnityGraphicsMetalV1, UnityGraphicsMetalV1Interface, UnityGraphicsMetalV2,
+};
+
+pub fn fill_texture(unity_texture: *mut c_void, x: f32, y: f32, z: f32, w: f32) {
+    if unity_texture.is_null() {
+        return;
+    }
+
+    unsafe {
+        let interfaces = UnityInterfaces::get();
+
+        let cmd_buffer: Retained<ProtocolObject<dyn MTLCommandBuffer>> =
+            if let Some(intf) = interfaces.interface::<UnityGraphicsMetalV2>() {
+                intf.end_current_command_encoder();
+                match intf.current_command_buffer() {
+                    Some(cb) => cb,
+                    None => return,
+                }
+            } else if let Some(intf) = interfaces.interface::<UnityGraphicsMetalV1>() {
+                intf.end_current_command_encoder();
+                match intf.current_command_buffer() {
+                    Some(cb) => cb,
+                    None => return,
+                }
+            } else {
+                return;
+            };
+
+        // Unity returns id<MTLTexture> directly from GetNativeTexturePtr() under Metal.
+        let texture: Retained<ProtocolObject<dyn MTLTexture>> =
+            match Retained::retain(unity_texture as *mut ProtocolObject<dyn MTLTexture>) {
+                Some(t) => t,
+                None => return,
+            };
+
+        let pass = MTLRenderPassDescriptor::new();
+        let attachment = pass.colorAttachments().objectAtIndexedSubscript(0);
+        attachment.setTexture(Some(&*texture));
+        attachment.setLoadAction(MTLLoadAction::Clear);
+        attachment.setStoreAction(MTLStoreAction::Store);
+        attachment.setClearColor(MTLClearColor {
+            red: x as f64,
+            green: y as f64,
+            blue: z as f64,
+            alpha: w as f64,
+        });
+
+        if let Some(encoder) = cmd_buffer.renderCommandEncoderWithDescriptor(&pass) {
+            encoder.endEncoding();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Metal backend to `unity-native-plugin-sample`'s `fill_texture` so Apple platforms are covered alongside D3D11 / D3D12 / Vulkan.
- Wire `metal` into the `unity-native-plugin` feature set and add Apple-only `objc2` / `objc2-metal` dependencies for the sample crate.
- Update the sample README to describe Metal usage, the `IUnityGraphicsMetalV2` (with V1 fallback) flow, and the `EndCurrentCommandEncoder` + one-shot clear render pass approach.