### PR TITLE
Add a binding for ReserveEventIDRange

### DIFF
--- a/unity-native-plugin/src/graphics.rs
+++ b/unity-native-plugin/src/graphics.rs
@@ -1,3 +1,4 @@
+use std::os::raw::c_int;
 use crate::define_unity_interface;
 use crate::interface::UnityInterface;
 use unity_native_plugin_sys::*;
@@ -71,5 +72,9 @@ impl UnityGraphics {
                 intf(std::mem::transmute(callback));
             }
         }
+    }
+
+    pub fn reserve_event_id_range(&self, count: c_int) -> c_int {
+        unsafe { self.interface().ReserveEventIDRange.expect("ReserveEventIDRange is missing")(count) }
     }
 }


### PR DESCRIPTION
Hello,

This PR adds a binding for `ReserveEventIDRange()`. This API is necessary to prevent Event IDs used by multiple plugins from overlapping. This API is particularly important when specific configurations for Event IDs are required, such as `ConfigureEvent()` in Vulkan.