### PR TITLE
CI: install toolchain via rustup, drop rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - uses: Swatinem/rust-cache@v2
+      - name: Update Rust toolchain
+        run: rustup update stable && rustup default stable && rustup component add clippy
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets


### PR DESCRIPTION
## Summary
- Replace `dtolnay/rust-toolchain@stable` with `rustup update stable && rustup default stable && rustup component add clippy`
- Remove `Swatinem/rust-cache@v2`

## Test plan
- [x] CI passes on `ubuntu-latest`
- [x] CI passes on `windows-latest`
- [x] CI passes on `macos-latest`